### PR TITLE
FEP draft

### DIFF
--- a/fep-7aa9.jsonld
+++ b/fep-7aa9.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "FeaturedCollection": "https://w3id.org/fep/7aa9#FeaturedCollection",
+    "FeaturedItem": "https://w3id.org/fep/7aa9#FeaturedItem",
+    "FeatureRequest": "https://w3id.org/fep/7aa9#FeatureRequest",
+    "FeatureAuthorization": "https://w3id.org/fep/7aa9#FeatureAuthorization",
+    "topic": {
+      "@id": "https://w3id.org/fep/7aa9#topic",
+      "@type": "@id"
+    },
+    "featuredObject": {
+      "@id": "https://w3id.org/fep/7aa9#featuredObject",
+      "@type": "@id"
+    },
+    "canFeature": {
+      "@id": "https://w3id.org/fep/7aa9#canFeature",
+      "@type": "@id"
+    },
+    "featureAuthorization": {
+      "@id": "https://w3id.org/fep/7aa9#featureAuthorization",
+      "@type": "@id"
+    }
+  }
+}

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -284,7 +284,12 @@ Example `Delete` activity:
   "type": "Delete",
   "to": "https://fedi.example.com/users/alice",
   "actor": "https://other.example.com/users/bob",
-  "object": "https://other.example.com/users/bob/stamps/1024"
+  "object": {
+    "id": "https://other.example.com/users/bob/stamps/1024",
+    "type": "FeatureAuthorization",
+    "interactingObject": "https://fedi.example.com/users/alice/featured/23",
+    "interactionTarget": "https://other.example.com/users/bob"
+  }
 }
 ```
 

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -1,0 +1,344 @@
+---
+slug: "xxxx"
+authors: David Roetzel <david@joinmastodon.org> 
+status: DRAFT
+dateReceived: 1970-01-01
+discussionsTo: https://forum.example/topics/xxxx
+---
+# FEP-xxxx: Consent-respecting Featured Collections
+
+## Summary
+
+This FEP describes both a new object type and mechanism to allow users to curate collections of other users (actors) and possibly other objects that they would like to recommend to others. These collections, sometimes referred to as "Starter Packs", help new users find interesting people and content to follow.
+
+Users are able to opt in to being included in these collections and can remove themselves from them. Problematic collections can be reported and moderated just like other content.
+
+## Background 
+
+"Starter Packs", a feature pioneered by Bluesky, have proven to be a brilliant way to help new users to find exactly the right people to follow. This can be an important tool to combat the "empty feed" problem that many new users experience on the fediverse and that sometimes turns them away. As such, there has been a lot of interest in implementing Starter Packs on the fediverse.
+
+But while the basic idea of a "Starter Pack" is quite simple, the federated nature of the network poses some challenges that need to be overcome. For example it should be possible to interact with remote "Starter Packs" that were created on a different server and possibly by a different software.
+
+Last but not least, "Starter Packs" need to be handled with care as they can be an easy vector for harassment. Users need control over which "Starter Packs" they are included in and "Starter Packs" need to be subject to the same moderation procedures already in place for other types of content.
+
+GoToSocial has pioneered "Interaction Policies" to model a user's preferences for different kinds of interactions. And in [FEP-044f] Mastodon has expanded on this idea with the addition of verifiable "stamps" to prove user's consent.
+
+This FEP takes those concepts and applies them to a user-curated and federated collection of actors (or any kind of object really) called `FeaturedCollection`. The name was chosen because some platforms already announced they do not plan to use the term "Starter Pack" and to illustrate that other uses are possible.
+
+## Representation of Featured Collections
+
+Featured collections are represented by a new object type, `FeaturedCollection`. `FeaturedCollection` is a subtype of `OrderedCollection` and inherits all of its properties.
+
+A `FeaturedCollection` MUST have the following properties:
+
+* `type`: The type of object, MUST be `FeaturedCollection`
+* `id`: IRI that uniquely identifies this object
+* `name`: The name of the collection
+* `summary`: A description of the collection
+* `attributedTo`: The actor responsible for this collection
+* `published`: The date and time at which the object was published
+* `totalItems`: The number of items in this collection
+* `orderedItems`: The list of items in this collection. Since this is a kind of `OrderedCollection` it MAY alternatively use pagination instead. This should only be used for larger collections if possible. Please see the note about limiting the number of entries below and the [note about paginated ordered collections](https://www.w3.org/TR/activitystreams-core/#h-paging) in [ActivityStreams].
+
+In addition, a `FeaturedCollection` MAY have the following property:
+
+* `sensitive`: Set to `true` if either description of the collection or individual items could be seen as being offensive or otherwise problematic
+* `updated`: The date and time at which the object was updated *if* it was updated after initial creation
+* `icon`: An image that represents the collection. This SHOULD be a square image that can be used in list views and similar alongside the `name`.
+* `image`: A larger image that can be used as a page header or as part of a link preview. Similar considerations apply as with OpenGraph images.
+
+It is worth emphasizing that both `icon` and `image` are separately optional. Providers of `FeaturedCollection`s may choose to supply both, only one, or neither. Applications displaying `FeaturedCollection`s may also elect to show or omit either or both images, depending on what makes sense in their UI design and the specific situation. This FEP considers these images decorative in nature, meaning they should not be the only source of important information.
+
+The individual items in the `FeaturedCollection` are of the type `FeaturedItem` which is a subtype of `Object`. A `FeaturedItem` MUST have the following property:
+
+* `featuredObject`: The `id` (IRI) of the actual object that is being featured
+* `featuredObjectType`: The `type` of the object that is being featured
+
+In the case that the featured object is an actor it MUST also include the following property:
+
+* `featureAuthorization`: URI of the approval object (see section below for details)
+
+Please note that initially the featured objects are expected to be actors. But the specification is intentionally open to also include other object types. The most obvious one that platforms might want to add in the future is `Hashtag`.
+
+Example featured collection:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/feps/xxxx"
+  ],
+  "type": "FeaturedCollection",
+  "id": "https://fedi.example.com/users/alice/featured/23",
+  "name": "Most interesting posters",
+  "summary": "A selection of accounts that I follow because of their interesting content.",
+  "attributedTo": "https://fedi.example.com/users/alice",
+  "sensitive": false,
+  "icon": {
+    "type": "Image",
+    "url": {
+      "type": "Link",
+      "mediaType": "image/jpeg",
+      "href": "https://fedi.example.com/assets/alice_sp_23.jpg"
+    }
+  },
+  "totalItems": 2,
+  "orderedItems": [
+    {
+      "id": "https://fedi.example.com/users/alice/featured/23/items/1",
+      "type": "FeaturedItem",
+      "featuredObject": "https://fedi.example.com/users/jennifer",
+      "featuredObjectType": "Person",
+      "featureAuthorization": "https://fedi.example.com/users/jennifer/stamps/12"
+    },
+    {
+      "id": "https://fedi.example.com/users/alice/featured/23/items/2",
+      "type": "FeaturedItem",
+      "featuredObject": "https://other.example.com/users/jim",
+      "featuredObjectType": "Person",
+      "featureAuthorization": "https://other.example.com/users/jim/stamps/21"
+    }
+  ],
+  "published": "2025-08-14T12:12:12Z",
+  "updated": "2025-08-14T13:17:25"
+}
+```
+
+Very large lists of items do not make much sense from a UX perspective. E.g. not many users will want to blindly follow a couple of hundred of unknown accounts. And forcing remote servers to potentially fetch a lot of unknown actors is a vector for Denial of Service (DOS). That is why fediverse software SHOULD both impose a limit to the number of items that can be added to a featured collection and that they will handle when dealing with remote collections. The proposed maximum of items is 150 but implementations MAY have different limits.
+
+## Featured Collections on Actors
+
+Featured collections are created by individual actors. As such they SHOULD become part of the actor's `featured` collection. This way other servers on the fediverse can easily discover them.
+
+## Federating Changes and Opportunistic Updating
+
+When a user creates a new `FeaturedCollection`, this is then added to their actor's `featured` collection, an operation that can be federated as an `Add` activity to the user's followers.
+
+Similarly, when a `FeaturedItem` is added to a `FeaturedCollection`, this can also be distributed in the form of an `Add` activity to all followers of the user that owns the collection and all actors that are already part of the collection.
+
+`Remove` activities can be sent in case of removal from one of the mentioned collections.
+
+This solves the distribution of featured collections and updates to them, but only to followers of their curator plus members of the collection.
+
+Featured collections will eventually end up on servers without any followers of that original curator, though. This means that implementations SHOULD try to re-fetch these collections from time to time to make sure the content is still current. 
+
+## Interaction Policies for Curated Collections
+
+Users MUST be able to consent to being included in featured collections. To signal a user's preferences in that regard an `interactionPolicy` object, as first introduced by GoToSocial, MUST be added to the user's actor. This `interactionPolicy` MUST have a property `canFeature`.
+
+Abbreviated example actor:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://gotosocial.org/ns",
+    "https://w3id.org/feps/xxxx"
+  ],
+  "id": "https://example.com/users/alice",
+  "type": "Person",
+  "interactionPolicy": {
+    "canFeature": {
+      "automaticApproval": [ "https://fedi.example.com/users/alice/followers" ],
+      "manualApproval": [ "https://www.w3.org/ns/activitystreams#Public" ]
+    }
+  }
+  // ...
+}
+```
+
+The two properties of the `canFeature` object can be used to signal who is always allowed to feature this actor in a featured collection (`automaticApproval`) and who might do so but would need a manual approval (`manualApproval`).
+
+The value in both cases MUST be an array consisting of actor objects, `Collection` of actor objects or the special collection `https://www.w3.org/ns/activitystreams#Public`. Note that the latter might also be represented as `as:Public` or simply `Public`. Implementations SHOULD handle all three possible representations.
+
+In practice, the only values that SHOULD be used are the `id` of the actor itself (see below), the `followers` and the `following` collection of the actor and `https://www.w3.org/ns/activitystreams#Public`.
+
+Actors not specifically mentioned or included in one of the collections are never allowed to feature the actor.
+
+The absence of an `interactionPolicy` MUST be treated as missing consent and the affected actors MUST NOT be added to featured collections ever.
+
+To make a policy of never wanting to be featured explicit, `interactionPolicy.canQuote.automaticApproval` SHOULD contain the actor's `id` as its single value. This is because an empty array is equivalent to a missing property under JSON-LD canonicalization. 
+
+In any case this general policy is just that, a general policy, and MUST NOT be confused with actual consent. This means that one can use this policy to determine which actors may be added to featured collections, but one always has to check if the approval for a specific featured collection was really given. See the next section for details.
+
+Note that this is modeled closely after interaction policies for quote posts (see [FEP-044f]).
+
+## Obtaining consent
+
+While interaction policies signal an actor's general preferences any attempt to include an actor in a featured collection MUST ask for consent explicitly.
+
+To do so a new activity type `FeatureRequest` is introduced. It has two mandatory properties:
+
+* `object`: The actor to be included in the featured collection
+* `instrument`: The featured collection
+
+When adding an actor to a featured collection the owner of said collection MUST send a `FeatureRequest` activity to the actor that is about to be added.
+
+Example `FeatureRequest`:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/feps/xxxx"
+  ],
+  "id": "https://fedi.example.com/users/alice/featured/23/requests/2",
+  "type": "FeatureRequest",
+  "object": "https://other.example.com/users/bob",
+  "instrument": "https://fedi.example.com/users/alice/featured/23"
+}
+```
+
+In response the actor can either issue an `Accept` or a `Reject` activity. In case of automatic approval, those can be issued immediately. In case of manual approval, a user needs to be notified and asked before the answer can be sent.
+
+In both cases, `Accept` or `Reject`, the object of the activity is the `FeatureRequest`. In case of an `Accept` the activity MUST also include a `result` property pointing to a `FeatureAuthorization`.
+
+Example `Accept` activity:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams"
+  ],
+  "type": "Accept",
+  "to": "https://fedi.example.com/users/alice",
+  "actor": "https://other.example.com/users/bob",
+  "object": "https://fedi.example.com/users/alice/featured/23/requests/2",
+  "result": "https://other.example.com/users/bob/stamps/1024"
+}
+```
+
+Example `Reject` activity:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams"
+  ],
+  "type": "Reject",
+  "to": "https://fedi.example.com/users/alice",
+  "actor": "https://other.example.com/users/bob",
+  "object": "https://fedi.example.com/users/alice/featured/23/requests/2",
+}
+```
+
+When the server that issued the `FeatureRequest` receives an `Accept` it SHOULD add a new `FeaturedItem` to the `FeaturedCollection` in which case the `featureAuthorization` property MUST include the `result` of the `Accept` activity.
+
+Example `FeaturedItem` resulting from the `Accept` above:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/feps/xxxx"
+  ],
+  "id": "https://fedi.example.com/users/alice/featured/23/items/2",
+  "type": "FeaturedItem",
+  "object": "https://other.example.com/users/bob",
+  "featureAuthorization": "https://other.example.com/users/bob/stamps/1024"
+}
+```
+
+In case of a `Reject`, a new `FeaturedItem` MUST NOT be created and nothing is added to the `FeaturedCollection`.
+
+## Verification
+
+The `FeatureAuthorization` obtained through the `Accept` activity as described in the previous section serves as an "approval stamp", an object that can be used to verify that approval to be included in a featured collection was given.
+
+A `FeatureAuthorization` MUST include the following properties:
+
+* `type`: The type of object, MUST be `FeatureAuthorization`
+* `id`: IRI that uniquely identifies this object
+* `interactingObject`: The featured collection 
+* `interactionTarget`: The actor that was featured
+ 
+Example `FeatureAuthorization`:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://gotosocial.org/ns",
+    "https://w3id.org/feps/xxxx"
+  ],
+  "id": "https://other.example.com/users/bob/stamps/1024",
+  "type": "FeatureAuthorization",
+  "interactingObject": "https://fedi.example.com/users/alice/featured/23",
+  "interactionTarget": "https://other.example.com/users/bob"
+}
+```
+
+When processing a `FeaturedCollection` from a remote server the `FeatureAuthorization` of every `FeaturedItem` MUST be validated. If it is missing, cannot be resolved or the hosting service does not match the actor's the item MUST be ignored or removed from the collection before it is being displayed to users. 
+
+## Revocation
+
+Actor's can opt out of being featured after the fact. In that case they MUST issue an `Delete` activity with the `FeatureAuthorization` as `object`.
+
+Example `Delete` activity:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams"
+  ],
+  "type": "Delete",
+  "to": "https://fedi.example.com/users/alice",
+  "actor": "https://other.example.com/users/bob",
+  "object": "https://other.example.com/users/bob/stamps/1024"
+}
+```
+
+When a `Delete` activity for a `FeatureAuthorization` is received the affected `FeaturedItem` MUST be removed from the `FeaturedCollection`.
+
+## Moderation
+
+Featured collections can include language or imagery that are against a given server's rules. As such it MUST be possible to report them and to handle reports received.
+
+Just like with other objects, a report is federated as a `Flag` activity and `FeaturedCollection` MAY be added to the list of reported objects:
+
+Example activity:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams"
+  ],
+  "id": "https://other.example.com/reports/17324",
+  "type": "Flag",
+  "actor": "https://other.example.com/actor",
+  "to": "https://fedi.example.com/users/alice",
+  "content": "Inappropriate language in collection description",
+  "objects": [
+    "https://fedi.example.com/users/alice",
+    "https://fedi.example.com/users/alice/featured/23"
+  ]
+}
+```
+
+## Implementation Guidelines
+
+The mechanisms described offer a lot of flexibility and thus can lead to some complexity in implementations. But implementations do not have to be complex to work. There is a spectrum of possibilities.
+
+At the lower end of that spectrum sit implementations that do not want to offer their users any control or agency at all. If you think it should always be possible for users to be featured, you can add the same interaction policy to every actor and simply always return positive authorizations. This can be a fully automated process with little overhead.
+
+Similarly an implementation could decide to never allow their users to be added. So either no, or a special interaction policy can be included and authorizations always denied.
+
+At the other end of the spectrum lie implementations that offer their users full flexibility. This would include fine-grained settings for both manual and automatic approval, leading to complex interaction policies. And for manual approval they would probably need a special UI notifying users of a request to be featured with affordances to either accept or deny that request.
+
+Of course there is a lot of middle ground here. A reasonable approach that sits somewhat in the middle could use automatic approval only and offer users a single setting for their preference with a handful of options to chose from. To make up for the lack of manual approval, removing oneself from a featured collection could be made very easy.
+
+## References
+
+- Christine Lemmer-Webber, Jessica Tallon, Erin Shepherd, Amy Guy, Evan Prodromou, [ActivityPub], 2018
+- James M Snell, Evan Prodromou, [ActivityStreams], 2017
+- Claire, [FEP-044f], 2025
+
+[ActivityPub]: https://www.w3.org/TR/activitypub/
+[ActivityStreams]: https://www.w3.org/TR/activitystreams-core/
+[FEP-044f]: https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md
+
+## Copyright
+
+CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
+
+To the extent possible under law, the authors of this Fediverse Enhancement Proposal have waived all copyright and related or neighboring rights to this work.

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -44,11 +44,16 @@ In addition, a `FeaturedCollection` MAY have the following property:
 
 * `sensitive`: Set to `true` if either description of the collection or individual items could be seen as being offensive or otherwise problematic
 * `updated`: The date and time at which the object was updated *if* it was updated after initial creation
-* `discoverable`: If present and set to `false` this signals that this collection is not meant to be discovered by search or similar means and MUST NOT be shown to new users during onboarding.
+* `tag`: This can be used to include a list of `Hashtag` objects that help categorize this collection. If the `summary` includes any (microsyntax) hashtags, their corresponding `Hashtag` objects SHOULD be included here.
 * `icon`: An image that represents the collection. This SHOULD be a square image that can be used in list views and similar alongside the `name`.
 * `image`: A larger image that can be used as a page header or as part of a link preview. Similar considerations apply as with OpenGraph images.
 
 It is worth emphasizing that both `icon` and `image` are separately optional. Providers of `FeaturedCollection`s may choose to supply both, only one, or neither. Applications displaying `FeaturedCollection`s may also elect to show or omit either or both images, depending on what makes sense in their UI design and the specific situation. This FEP considers these images decorative in nature, meaning they should not be the only source of important information.
+
+This FEP also introduces two new properties that MAY optionally be used in a `FeaturedCollection`:
+
+* `discoverable`: If present and set to `false` this signals that this collection is not meant to be discovered by search or similar means and MUST NOT be shown to new users during onboarding.
+* `topic`: A single `Hashtag` object that represents the main topic or category of this collection.
 
 The individual items in the `FeaturedCollection` are of the type `FeaturedItem` which is a subtype of `Object`. A `FeaturedItem` MUST have the following property:
 

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -76,10 +76,15 @@ Example featured collection:
   ],
   "type": "FeaturedCollection",
   "id": "https://fedi.example.com/users/alice/featured/23",
-  "name": "Most interesting posters",
-  "summary": "A selection of accounts that I follow because of their interesting content.",
+  "name": "Cute cats",
+  "summary": "A selection of accounts that I follow because of their interesting cat content.",
   "attributedTo": "https://fedi.example.com/users/alice",
   "sensitive": false,
+  "discoverable": true,
+  "topic": {
+    "type": "Hashtag",
+    "name": "#cats"
+  },
   "icon": {
     "type": "Image",
     "url": {

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -114,11 +114,11 @@ Very large lists of items do not make much sense from a UX perspective. E.g. not
 
 ## Featured Collections on Actors
 
-Featured collections are created by individual actors. As such they SHOULD become part of the actor's `featured` collection. This way other servers on the fediverse can easily discover them.
+Featured collections are created by individual actors. As such they SHOULD become part of a new collection property on the actor, `featuredCollections`. This way other servers on the fediverse can easily discover them.
 
 ## Federating Changes and Opportunistic Updating
 
-When a user creates a new `FeaturedCollection`, this is then added to their actor's `featured` collection, an operation that can be federated as an `Add` activity to the user's followers.
+When a user creates a new `FeaturedCollection`, this is then added to their actor's `featuredCollections` collection, an operation that can be federated as an `Add` activity to the user's followers.
 
 Similarly, when a `FeaturedItem` is added to a `FeaturedCollection`, this can also be distributed in the form of an `Add` activity to all followers of the user that owns the collection and all actors that are already part of the collection.
 

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -32,7 +32,7 @@ Featured collections are represented by a new object type, `FeaturedCollection`.
 A `FeaturedCollection` MUST have the following properties:
 
 * `type`: The type of object, MUST be `FeaturedCollection`
-* `id`: IRI that uniquely identifies this object
+* `id`: URI that uniquely identifies this object
 * `name`: The name of the collection
 * `summary`: A description of the collection
 * `attributedTo`: The actor responsible for this collection
@@ -57,7 +57,7 @@ This FEP also introduces two new properties that MAY optionally be used in a `Fe
 
 The individual items in the `FeaturedCollection` are of the type `FeaturedItem` which is a subtype of `Object`. A `FeaturedItem` MUST have the following property:
 
-* `featuredObject`: The `id` (IRI) of the actual object that is being featured
+* `featuredObject`: The `id` (URI) of the actual object that is being featured
 * `featuredObjectType`: The `type` of the object that is being featured
 
 In the case that the featured object is an actor it MUST also include the following property:
@@ -254,7 +254,7 @@ The `FeatureAuthorization` obtained through the `Accept` activity as described i
 A `FeatureAuthorization` MUST include the following properties:
 
 * `type`: The type of object, MUST be `FeatureAuthorization`
-* `id`: IRI that uniquely identifies this object
+* `id`: URI that uniquely identifies this object
 * `interactingObject`: The featured collection 
 * `interactionTarget`: The actor that was featured
  

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -358,6 +358,11 @@ At the other end of the spectrum lie implementations that offer their users full
 
 Of course there is a lot of middle ground here. A reasonable approach that sits somewhat in the middle could use automatic approval only and offer users a single setting for their preference with a handful of options to chose from. To make up for the lack of manual approval, removing oneself from a featured collection could be made very easy.
 
+## Implementations
+
+* Loops
+* Mastodon
+
 ## References
 
 - Christine Lemmer-Webber, Jessica Tallon, Erin Shepherd, Amy Guy, Evan Prodromou, [ActivityPub], 2018

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -2,7 +2,7 @@
 slug: "7aa9"
 authors: David Roetzel <david@joinmastodon.org> 
 status: DRAFT
-dateReceived:
+dateReceived: 2026-06-12
 discussionsTo: https://github.com/mastodon/featured_collections/pull/1
 ---
 # FEP-7aa9: Featuring recommendations using a dedicated collection

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -37,7 +37,7 @@ A `FeaturedCollection` MUST have the following properties:
 * `attributedTo`: The actor responsible for this collection
 * `orderedItems`: The list of items in this collection. Since this is a kind of `OrderedCollection` it MAY alternatively use pagination instead. This should only be used for larger collections if possible. Please see the note about limiting the number of entries below and the [note about paginated ordered collections](https://www.w3.org/TR/activitystreams-core/#h-paging) in [ActivityStreams].
 
-In addition, a `FeaturedCollection` MAY have the following property:
+In addition, a `FeaturedCollection` MAY have the following properties:
 
 * `summary`: A description of the collection
 * `sensitive`: Set to `true` if either description of the collection or individual items could be seen as being offensive or otherwise problematic

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -1,11 +1,11 @@
 ---
-slug: "xxxx"
+slug: "7aa9"
 authors: David Roetzel <david@joinmastodon.org> 
 status: DRAFT
-dateReceived: 1970-01-01
-discussionsTo: https://forum.example/topics/xxxx
+dateReceived:
+discussionsTo: https://github.com/mastodon/featured_collections/pull/1
 ---
-# FEP-xxxx: Consent-respecting Featured Collections
+# FEP-7aa9: Featuring recommendations using a dedicated collection
 
 ## Summary
 
@@ -23,46 +23,51 @@ Last but not least, "Starter Packs" need to be handled with care as they can be 
 
 GoToSocial has pioneered "Interaction Policies" to model a user's preferences for different kinds of interactions. And in [FEP-044f] Mastodon has expanded on this idea with the addition of verifiable "stamps" to prove user's consent.
 
-This FEP takes those concepts and applies them to a user-curated and federated collection of actors (or any kind of object really) called `FeaturedCollection`. The name was chosen because some platforms already announced they do not plan to use the term "Starter Pack" and to illustrate that other uses are possible.
+This FEP takes those concepts and applies them to a user-curated and federated collection of actors (or any kind of object really) called `FeaturedCollection`. The name was chosen because some platforms already announced they do not plan to use the term "Starter Pack" and to illustrate that other uses, i.e. featuring other objects than just actors, are possible.
 
 ## Representation of Featured Collections
 
-Featured collections are represented by a new object type, `FeaturedCollection`. `FeaturedCollection` is a subtype of `OrderedCollection` and inherits all of its properties.
+Featured collections are represented by a new object type, `FeaturedCollection` (`https://w3id.org/fep/7aa9/#FeaturedCollection`). `FeaturedCollection` is a subtype of `OrderedCollection` and inherits all of its properties.
 
 A `FeaturedCollection` MUST have the following properties:
 
-* `type`: The type of object, MUST be `FeaturedCollection`
+* `type`: The type of object, MUST include `FeaturedCollection`
 * `id`: URI that uniquely identifies this object
 * `name`: The name of the collection
-* `summary`: A description of the collection
 * `attributedTo`: The actor responsible for this collection
-* `published`: The date and time at which the object was published
-* `totalItems`: The number of items in this collection
 * `orderedItems`: The list of items in this collection. Since this is a kind of `OrderedCollection` it MAY alternatively use pagination instead. This should only be used for larger collections if possible. Please see the note about limiting the number of entries below and the [note about paginated ordered collections](https://www.w3.org/TR/activitystreams-core/#h-paging) in [ActivityStreams].
 
 In addition, a `FeaturedCollection` MAY have the following property:
 
+* `summary`: A description of the collection
 * `sensitive`: Set to `true` if either description of the collection or individual items could be seen as being offensive or otherwise problematic
+* `published`: The date and time at which the object was published
 * `updated`: The date and time at which the object was updated *if* it was updated after initial creation
-* `tag`: This can be used to include a list of `Hashtag` objects that help categorize this collection. If the `summary` includes any (microsyntax) hashtags, their corresponding `Hashtag` objects SHOULD be included here.
-* `icon`: An image that represents the collection. This SHOULD be a square image that can be used in list views and similar alongside the `name`.
+* `totalItems`: The number of items in this collection
+* `tag`: If the `summary` includes any (microsyntax) hashtags, their corresponding `Hashtag` objects SHOULD be included here.
+* `url`: A link to a representation of the collection, especially useful if the canonical, user-facing URL of a collection is different from its `id`
+* `icon`: An image that represents the collection. This MUST be a square image that can be used in list views and similar alongside the `name`.
 * `image`: A larger image that can be used as a page header or as part of a link preview. Similar considerations apply as with OpenGraph images.
 
 It is worth emphasizing that both `icon` and `image` are separately optional. Providers of `FeaturedCollection`s may choose to supply both, only one, or neither. Applications displaying `FeaturedCollection`s may also elect to show or omit either or both images, depending on what makes sense in their UI design and the specific situation. This FEP considers these images decorative in nature, meaning they should not be the only source of important information.
 
 This FEP also introduces two new properties that MAY optionally be used in a `FeaturedCollection`:
 
-* `discoverable`: If present and set to `false` this signals that this collection is not meant to be discovered by search or similar means and MUST NOT be shown to new users during onboarding.
-* `topic`: A single `Hashtag` object that represents the main topic or category of this collection.
+* `discoverable` (`https://w3id.org/fep/7aa9/#discoverable`): If present and set to `false` this signals that this collection is not meant to be discovered by search or similar means and MUST NOT be shown to new users during onboarding.
+* `topic` (`https://w3id.org/fep/7aa9/#topic`): A single `Hashtag` object that represents the main topic or category of this collection.
 
-The individual items in the `FeaturedCollection` are of the type `FeaturedItem` which is a subtype of `Object`. A `FeaturedItem` MUST have the following property:
+The individual items in the `FeaturedCollection` are of the type `FeaturedItem` (`https://w3id.org/fep/7aa9/#FeaturedItem`) which is a subtype of `Object`. A `FeaturedItem` MUST have the following property:
 
-* `featuredObject`: The `id` (URI) of the actual object that is being featured
-* `featuredObjectType`: The `type` of the object that is being featured
+* `featuredObject` (`https://w3id.org/fep/7aa9/#featuredObject`): The `id` (URI) of the actual object that is being featured
+* `featuredObjectType` (`https://w3id.org/fep/7aa9/#featuredObjectType`): The `type` of the object that is being featured
 
 In the case that the featured object is an actor it MUST also include the following property:
 
-* `featureAuthorization`: URI of the approval object (see section below for details)
+* `featureAuthorization` (`https://w3id.org/fep/7aa9/#featureAuthorization`): URI of the approval object (see section below for details)
+
+In addition, a `FeaturedItem` MAY have the following property:
+
+* `published`: The date and time at which the object was added to the collection
 
 Please note that initially the featured objects are expected to be actors. But the specification is intentionally open to also include other object types. The most obvious one that platforms might want to add in the future is `Hashtag`.
 
@@ -72,7 +77,7 @@ Example featured collection:
 {
   "@context": [
     "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/feps/xxxx"
+    "https://w3id.org/fep/7aa9"
   ],
   "type": "FeaturedCollection",
   "id": "https://fedi.example.com/users/alice/featured/23",
@@ -100,14 +105,16 @@ Example featured collection:
       "type": "FeaturedItem",
       "featuredObject": "https://fedi.example.com/users/jennifer",
       "featuredObjectType": "Person",
-      "featureAuthorization": "https://fedi.example.com/users/jennifer/stamps/12"
+      "featureAuthorization": "https://fedi.example.com/users/jennifer/stamps/12",
+      "published": "2025-08-14T12:13:22Z"
     },
     {
       "id": "https://fedi.example.com/users/alice/featured/23/items/2",
       "type": "FeaturedItem",
       "featuredObject": "https://other.example.com/users/jim",
       "featuredObjectType": "Person",
-      "featureAuthorization": "https://other.example.com/users/jim/stamps/21"
+      "featureAuthorization": "https://other.example.com/users/jim/stamps/21",
+      "published": "2025-08-14T12:14:51Z"
     }
   ],
   "published": "2025-08-14T12:12:12Z",
@@ -144,7 +151,7 @@ Abbreviated example actor:
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://gotosocial.org/ns",
-    "https://w3id.org/feps/xxxx"
+    "https://w3id.org/fep/7aa9"
   ],
   "id": "https://example.com/users/alice",
   "type": "Person",
@@ -191,7 +198,7 @@ Example `FeatureRequest`:
 {
   "@context": [
     "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/feps/xxxx"
+    "https://w3id.org/fep/7aa9"
   ],
   "id": "https://fedi.example.com/users/alice/featured/23/requests/2",
   "type": "FeatureRequest",
@@ -241,12 +248,14 @@ Example `FeaturedItem` resulting from the `Accept` above:
 {
   "@context": [
     "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/feps/xxxx"
+    "https://w3id.org/fep/7aa9"
   ],
   "id": "https://fedi.example.com/users/alice/featured/23/items/2",
   "type": "FeaturedItem",
   "object": "https://other.example.com/users/bob",
-  "featureAuthorization": "https://other.example.com/users/bob/stamps/1024"
+  "featuredObjectType": "Person",
+  "featureAuthorization": "https://other.example.com/users/bob/stamps/1024",
+  "published": "2025-08-14T12:13:22Z"
 }
 ```
 
@@ -270,7 +279,7 @@ Example `FeatureAuthorization`:
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://gotosocial.org/ns",
-    "https://w3id.org/feps/xxxx"
+    "https://w3id.org/fep/7aa9"
   ],
   "id": "https://other.example.com/users/bob/stamps/1024",
   "type": "FeatureAuthorization",

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -44,6 +44,7 @@ In addition, a `FeaturedCollection` MAY have the following property:
 
 * `sensitive`: Set to `true` if either description of the collection or individual items could be seen as being offensive or otherwise problematic
 * `updated`: The date and time at which the object was updated *if* it was updated after initial creation
+* `discoverable`: If present and set to `false` this signals that this collection is not meant to be discovered by search or similar means and MUST NOT be shown to new users during onboarding.
 * `icon`: An image that represents the collection. This SHOULD be a square image that can be used in list views and similar alongside the `name`.
 * `image`: A larger image that can be used as a page header or as part of a link preview. Similar considerations apply as with OpenGraph images.
 

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -118,15 +118,15 @@ Featured collections are created by individual actors. As such they SHOULD becom
 
 ## Federating Changes and Opportunistic Updating
 
-When a user creates a new `FeaturedCollection`, this is then added to their actor's `featuredCollections` collection, an operation that can be federated as an `Add` activity to the user's followers.
+When a user creates a new `FeaturedCollection`, this is then added to their actor's `featuredCollections` collection, an operation that can be federated as an `Add` activity.
 
-Similarly, when a `FeaturedItem` is added to a `FeaturedCollection`, this can also be distributed in the form of an `Add` activity to all followers of the user that owns the collection and all actors that are already part of the collection.
+Similarly, when a `FeaturedItem` is added to a `FeaturedCollection`, this can also be distributed in the form of an `Add` activity.
 
 `Remove` activities can be sent in case of removal from one of the mentioned collections.
 
-This solves the distribution of featured collections and updates to them, but only to followers of their curator plus members of the collection.
+A `FeaturedCollection` can be discovered by different means, which means a server can never know exactly who knows about it. When addressing the aforementioned activities a server SHOULD thus use a heuristic to determine who to send them to. A reasonable heuristic could be to send all changes to an actor's `featuredCollections` collection to the actor's followers. Additionally all changes to an individual `FeaturedCollection` could also go to all actors in that collection (including the one that was just removed in case of `Remove`).
 
-Featured collections will eventually end up on servers without any followers of that original curator, though. This means that implementations SHOULD try to re-fetch these collections from time to time to make sure the content is still current. 
+No such heuristic will ever be perfect though. Servers who know about a `FeaturedCollection` might still not receive relevant updates. This means that implementations SHOULD try to re-fetch these collections from time to time to make sure the content is still current. 
 
 ## Interaction Policies for Curated Collections
 

--- a/fep-draft.md
+++ b/fep-draft.md
@@ -27,7 +27,7 @@ This FEP takes those concepts and applies them to a user-curated and federated c
 
 ## Representation of Featured Collections
 
-Featured collections are represented by a new object type, `FeaturedCollection` (`https://w3id.org/fep/7aa9/#FeaturedCollection`). `FeaturedCollection` is a subtype of `OrderedCollection` and inherits all of its properties.
+Featured collections are represented by a new object type, `FeaturedCollection` (`https://w3id.org/fep/7aa9#FeaturedCollection`). `FeaturedCollection` is a subtype of `OrderedCollection` and inherits all of its properties.
 
 A `FeaturedCollection` MUST have the following properties:
 
@@ -41,6 +41,7 @@ In addition, a `FeaturedCollection` MAY have the following properties:
 
 * `summary`: A description of the collection
 * `sensitive`: Set to `true` if either description of the collection or individual items could be seen as being offensive or otherwise problematic
+* `discoverable` (`https://joinmastodon.org/ns#discoverable`): If present and set to `false` this signals that this collection is not meant to be discovered by search or similar means and MUST NOT be shown to new users during onboarding.
 * `published`: The date and time at which the object was published
 * `updated`: The date and time at which the object was updated *if* it was updated after initial creation
 * `totalItems`: The number of items in this collection
@@ -51,19 +52,17 @@ In addition, a `FeaturedCollection` MAY have the following properties:
 
 It is worth emphasizing that both `icon` and `image` are separately optional. Providers of `FeaturedCollection`s may choose to supply both, only one, or neither. Applications displaying `FeaturedCollection`s may also elect to show or omit either or both images, depending on what makes sense in their UI design and the specific situation. This FEP considers these images decorative in nature, meaning they should not be the only source of important information.
 
-This FEP also introduces two new properties that MAY optionally be used in a `FeaturedCollection`:
+This FEP also introduces a new property that MAY optionally be used in a `FeaturedCollection`:
 
-* `discoverable` (`https://w3id.org/fep/7aa9/#discoverable`): If present and set to `false` this signals that this collection is not meant to be discovered by search or similar means and MUST NOT be shown to new users during onboarding.
-* `topic` (`https://w3id.org/fep/7aa9/#topic`): A single `Hashtag` object that represents the main topic or category of this collection.
+* `topic` (`https://w3id.org/fep/7aa9#topic`): A single `Hashtag` object that represents the main topic or category of this collection.
 
-The individual items in the `FeaturedCollection` are of the type `FeaturedItem` (`https://w3id.org/fep/7aa9/#FeaturedItem`) which is a subtype of `Object`. A `FeaturedItem` MUST have the following property:
+The individual items in the `FeaturedCollection` are of the type `FeaturedItem` (`https://w3id.org/fep/7aa9#FeaturedItem`) which is a subtype of `Object`. A `FeaturedItem` MUST have the following property:
 
-* `featuredObject` (`https://w3id.org/fep/7aa9/#featuredObject`): The `id` (URI) of the actual object that is being featured
-* `featuredObjectType` (`https://w3id.org/fep/7aa9/#featuredObjectType`): The `type` of the object that is being featured
+* `featuredObject` (`https://w3id.org/fep/7aa9#featuredObject`): The `id` (URI) of the actual object that is being featured
 
 In the case that the featured object is an actor it MUST also include the following property:
 
-* `featureAuthorization` (`https://w3id.org/fep/7aa9/#featureAuthorization`): URI of the approval object (see section below for details)
+* `featureAuthorization` (`https://w3id.org/fep/7aa9#featureAuthorization`): URI of the approval object (see section below for details)
 
 In addition, a `FeaturedItem` MAY have the following property:
 
@@ -77,7 +76,12 @@ Example featured collection:
 {
   "@context": [
     "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/fep/7aa9"
+    "https://w3id.org/fep/7aa9",
+    {
+      "Hashtag": "as:Hashtag",
+      "sensitive": "as:sensitive",
+      "discoverable": "https://joinmastodon.org/ns#discoverable"
+    }
   ],
   "type": "FeaturedCollection",
   "id": "https://fedi.example.com/users/alice/featured/23",
@@ -123,6 +127,8 @@ Example featured collection:
 ```
 
 Very large lists of items do not make much sense from a UX perspective. E.g. not many users will want to blindly follow a couple of hundred of unknown accounts. And forcing remote servers to potentially fetch a lot of unknown actors is a vector for Denial of Service (DOS). That is why fediverse software SHOULD both impose a limit to the number of items that can be added to a featured collection and that they will handle when dealing with remote collections. The proposed maximum of items is 150 but implementations MAY have different limits.
+
+All properties mentioned are expected to have at most one value unless stated otherwise.
 
 ## Featured Collections on Actors
 


### PR DESCRIPTION
This is a first draft of how we could approach federating Starter Packs. Huge parts are closely modeled after [our quote posts FEP](https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md).

The following are additional remarks I would like to point out, some giving a bit more background and some highlighting areas with open questions.

## Prior art

Starter Packs were of course pioneered by Bluesky. So we had a look at that, but there were also some initiatives last year to bring them to the fediverse.

We specifically looked at [this issue on Github](https://github.com/pixelfed/starter-kits/issues/1) that includes a great discussion about how to represent Starter Packs in ActivityStreams.

We also looked at [Fedidevs](https://fedidevs.com/starter-packs/), a service that picked up those ideas to offer Starter Packs as a dedicated service outside of existing fediverse software.

## Goals

* Build on the existing discussions about representation and only change what we think is absolutely necessary
* Federate it (this goes beyond representation in AS: when Alice creates a Starter Pack on her server a.com then Bob should be able to see, use and interact with it on his server b.com)
* Respect consent. Not everyone wants to be included in Starter Packs and sometimes it might be necessary to remove yourself from a Starter Pack after the fact
* Make it reportable / moderatable: Starter Packs can and will be used to harass people ("List of the dumbest people on fedi"). We need to take this into account from day 1.
* The most important use-case is onboarding of new users. They face the problem of an empty timeline / feed and having Starter Packs to help them quickly find interesting accounts to follow is our number one priority.

## Non-goal (for now)

* Display Starter Packs in timeline/feed

While this would be nice to have it is surprisingly hard to implement. There are questions around when is a Starter Pack actually finished (imagine someone creates one and then slowly adds users one by one) and when to insert it into feeds if you need to check consent first and so on.

We decided it is not worth tackling this initially, as it has limited value. Entries in a timeline / feed scroll by and are replaced by the latest posts quickly. That means they are easy to overlook and/or forgotten quickly.

It is much more important to us that Starter Packs can be easily found, ideally across servers.

## Naming

As explained in the draft I did not name the new object type "StarterPack" because a) others have already announced they want to use a different term and b) because I envision other use cases.

## Representation of Starter Packs

As I said, we looked at [this existing proposal](https://github.com/pixelfed/starter-kits/issues/1) which includes many good and important ideas.

But we still decided to make some changes:

* Introduce a custom object type, as we need to introduce custom vocabulary anyway, so we thought we might as well make it more explicit / less ambiguous what this here is
* Base it on `OrderedCollection`. Some people spend a lot of time curating these things and the order of entries might be important to them.
* We always expect a Starter Pack to have an author, so `attributedTo` is mandatory.
* Allow an optional `icon` and an `image`
* Allow marking as `sensitive` (in case that for example the description,  account descriptions or images might be problematic)
* Items have their own type (see "Modeling consent" below)

## Limiting the number of entries

Arbitrary numbers of items would introduce a vector for Denial of Service. And also from a UX perspective it makes sense to limit the number of items.

Bluesky has a limit of 150 entries. I just copied that for now, but I personally believe we might get away with a much lower number. I can totally see that for example people in larger communities or organizations would love to curate lists of all members. But from a new user's perspective I think the larger the number of entries the lower the likelihood that they would hit a "Follow All" button.

I would love to read what thoughts others have on this question.

## Placement in the "featured collection"

Mastodon already has a per actor "featured collection", which currently includes individual posts that are being featured.

We wanted to reuse and build on that.

*But* this leads to the awkward situation that we want to put `FeaturedCollection`s into the "featured collection" which is at least a tiny bit weird :grimacing:

## Modeling consent

I mentioned this several times already: When it comes to signaling, validating and retracting consent I tried to copy as much from our quote posts FEP as possible. Months of consultation and discussion went into this. Also we recently enabled our implementation on our servers and are making our first real-world experiences with it.

It just made no sense to re-invent the wheel here, especially not in a way that is significantly different.

I tried to address the fact that (simple) implementations need not be very complex, but of course it is never trivial to implement.